### PR TITLE
Fix GitHub Pages paths

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <title>Tower Defense</title>
   
-  <script type="module" crossorigin src="/assets/index-4351ccb7.js"></script>
-  <link rel="stylesheet" href="/assets/index-711a8f82.css">
+  <script type="module" crossorigin src="./assets/index-4351ccb7.js"></script>
+  <link rel="stylesheet" href="./assets/index-711a8f82.css">
 </head>
 <body>
   <div id="hud">💰0</div>

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <title>Tower Defense</title>
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body>
   <div id="hud">💰0</div>
   <div id="intro" class="overlay">Click to start. Place towers by clicking the canvas.</div>
   <canvas id="game"></canvas>
-  <script type="module" src="/src/main.js"></script>
+  <script type="module" src="./src/main.js"></script>
 </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
 export default {
-  root: '.',
+  base: './',
   build: {
     outDir: 'docs'
   }


### PR DESCRIPTION
## Summary
- use relative paths in `index.html`
- add Vite `base` option
- rebuild docs so assets load correctly on GitHub Pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68505e0eb198832aabd7953ee412ebdd