### PR TITLE
Update README for docs-based GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 chmod +x setup.sh
 ./setup.sh
 ```
+This script installs dependencies and builds the game into the `/docs` folder for easy deployment on GitHub Pages.
 
 When ready for local development:
 ```bash
@@ -12,7 +13,7 @@ npm install
 npm run dev
 ```
 
-GitHub Pages deployment is automated to the `gh-pages` branch.
+GitHub Pages serves the site from the `/docs` folder on the `main` branch.
 
 ## 🎮 How to Play
 


### PR DESCRIPTION
## Summary
- explain that `./setup.sh` builds to `/docs`
- clarify that GitHub Pages serves from `/docs` on `main`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68508bdc388c832ab7a20c92c0c30e87